### PR TITLE
[BUBO-42] Serialize server action errors

### DIFF
--- a/src/components/sections/profile/SetUserAliasForm.tsx
+++ b/src/components/sections/profile/SetUserAliasForm.tsx
@@ -16,6 +16,7 @@ import {
 import {Button} from '@/components/ui/Button'
 import {useSetUserAlias} from '@/lib/queries/user/setUserAlias'
 import {FormError} from '@/lib/types/error'
+import {toast} from '@/components/ui/Toast'
 
 const formSchema = z.object({
   alias: z.string().min(3),
@@ -41,6 +42,7 @@ const SetUserAliasForm = ({initialAlias}: SetUserAliasFormProps) => {
     getValues,
     control,
     formState: {isDirty},
+    reset,
   } = form
 
   const onSubmit = () => {
@@ -50,6 +52,10 @@ const SetUserAliasForm = ({initialAlias}: SetUserAliasFormProps) => {
         if (error instanceof FormError) {
           form.setError('alias', {type: 'custom', message: error.message})
         }
+      },
+      onSuccess: () => {
+        reset(getValues(), {keepValues: true})
+        toast({title: 'Alias set.'})
       },
     })
   }

--- a/src/lib/queries/contest/getContests.ts
+++ b/src/lib/queries/contest/getContests.ts
@@ -7,10 +7,11 @@ import {
   getPublicContests,
   type GetPublicContestsParams,
 } from '@/server/actions/contest/getContests'
+import {withApiErrorHandler} from '@/lib/utils/common/error'
 
 const getQueryOptions = (params: GetPublicContestsParams) => ({
   queryKey: queryKeys.contests.public(params).queryKey,
-  queryFn: () => getPublicContests(params),
+  queryFn: withApiErrorHandler(() => getPublicContests(params)),
 })
 
 export const useGetPublicContests = (params: GetPublicContestsParams) =>

--- a/src/lib/queries/deduplicatedFinding/editDeduplicatedFinding.ts
+++ b/src/lib/queries/deduplicatedFinding/editDeduplicatedFinding.ts
@@ -23,7 +23,7 @@ export const useMergeDeduplicatedFindings = (
     mutationFn: withApiErrorHandler(mergeDeduplicatedFindings),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: queryKeys.deduplicatedFindings.all._def,
+        queryKey: queryKeys.deduplicatedFindings._def,
       })
     },
   })

--- a/src/lib/queries/deduplicatedFinding/getDeduplicatedFinding.ts
+++ b/src/lib/queries/deduplicatedFinding/getDeduplicatedFinding.ts
@@ -7,10 +7,11 @@ import {
   getDeduplicatedFindings,
 } from '@/server/actions/deduplicatedFinding/getDeduplicatedFinding'
 import getServerQueryClient from '@/server/utils/queryClient'
+import {withApiErrorHandler} from '@/lib/utils/common/error'
 
 const getQueryOptions = (params: GetDeduplicatedFindingsParams) => ({
   queryKey: queryKeys.deduplicatedFindings.all(params).queryKey,
-  queryFn: () => getDeduplicatedFindings(params),
+  queryFn: withApiErrorHandler(() => getDeduplicatedFindings(params)),
 })
 
 export const useGetDeduplicatedFindings = (

--- a/src/lib/queries/finding/editFinding.ts
+++ b/src/lib/queries/finding/editFinding.ts
@@ -33,7 +33,7 @@ export const useApproveOrRejectFinding = (
     mutationFn: withApiErrorHandler(approveOrRejectFinding),
     onSuccess: () => {
       void queryClient.invalidateQueries({
-        queryKey: queryKeys.deduplicatedFindings.all._def,
+        queryKey: queryKeys.deduplicatedFindings._def,
       })
     },
   })

--- a/src/lib/queries/reward/calculateRewards.ts
+++ b/src/lib/queries/reward/calculateRewards.ts
@@ -6,6 +6,7 @@ import {
   CalculateRewardsResponse,
   calculateRewards,
 } from '@/server/actions/reward/calculateRewards'
+import {withApiErrorHandler} from '@/lib/utils/common/error'
 
 export const useCalculatedRewards = (
   contestId: string,
@@ -13,7 +14,7 @@ export const useCalculatedRewards = (
 ) => {
   return useQuery({
     ...options,
-    queryFn: () => calculateRewards(contestId),
+    queryFn: withApiErrorHandler(() => calculateRewards(contestId)),
     queryKey: queryKeys.rewards.calculated(contestId).queryKey,
   })
 }

--- a/src/lib/queries/reward/getRewards.ts
+++ b/src/lib/queries/reward/getRewards.ts
@@ -7,10 +7,11 @@ import {
   getRewards,
   type GetRewardsParams,
 } from '@/server/actions/reward/getReward'
+import {withApiErrorHandler} from '@/lib/utils/common/error'
 
 const getQueryOptions = (params: GetRewardsParams) => ({
   queryKey: queryKeys.rewards.all(params).queryKey,
-  queryFn: () => getRewards(params),
+  queryFn: withApiErrorHandler(() => getRewards(params)),
 })
 
 export const useGetRewards = (params: GetRewardsParams) =>

--- a/src/lib/queries/reward/payReward.ts
+++ b/src/lib/queries/reward/payReward.ts
@@ -16,7 +16,7 @@ const payReward = async (browserWallet: BrowserWallet, rewardId: string) => {
     amount,
     walletAddress: receiverAddress,
     transferTxHash,
-  } = await getRewardPaymentDetails(rewardId)
+  } = handleApiErrors(await getRewardPaymentDetails(rewardId))
 
   if (!receiverAddress) {
     throw new Error("The auditor hasn't added his wallet address yet.")

--- a/src/lib/queries/user/addWalletAddress.ts
+++ b/src/lib/queries/user/addWalletAddress.ts
@@ -10,6 +10,7 @@ import {requireConnectedWallet} from '../../utils/client/wallet'
 
 import {verifyAndAddWalletAddress} from '@/server/actions/user/verifyAndAddWalletAddress'
 import {formatWalletSignMessage} from '@/lib/utils/common/wallet'
+import {withApiErrorHandler} from '@/lib/utils/common/error'
 
 const addWalletAddress = async (browserWallet: BrowserWallet) => {
   const wallet = await requireConnectedWallet(browserWallet)
@@ -48,7 +49,7 @@ export const useAddWalletAddress = () => {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: () => addWalletAddress(wallet),
+    mutationFn: withApiErrorHandler(() => addWalletAddress(wallet)),
     onSuccess: () => {
       void queryClient.invalidateQueries({
         queryKey: queryKeys.users.detail._def,

--- a/src/lib/queries/user/getUser.ts
+++ b/src/lib/queries/user/getUser.ts
@@ -9,7 +9,9 @@ import {withApiErrorHandler} from '@/lib/utils/common/error'
 
 const getQueryOptions = (userId: string | undefined) => ({
   queryKey: queryKeys.users.detail(userId).queryKey,
-  queryFn: withApiErrorHandler(getUser),
+  // getUser has to be explicitly called without arguments, otherwise React Query
+  // would inject context, which is not serializable for server actions
+  queryFn: withApiErrorHandler(() => getUser()),
 })
 
 export const useGetUser = () => {

--- a/src/lib/queries/user/getUser.ts
+++ b/src/lib/queries/user/getUser.ts
@@ -5,10 +5,11 @@ import {useUserId} from '../../hooks/useUserId'
 
 import {getUser} from '@/server/actions/user/getUser'
 import getServerQueryClient from '@/server/utils/queryClient'
+import {withApiErrorHandler} from '@/lib/utils/common/error'
 
 const getQueryOptions = (userId: string | undefined) => ({
   queryKey: queryKeys.users.detail(userId).queryKey,
-  queryFn: () => getUser(),
+  queryFn: withApiErrorHandler(getUser),
 })
 
 export const useGetUser = () => {

--- a/src/lib/types/error.ts
+++ b/src/lib/types/error.ts
@@ -17,3 +17,10 @@ export class ZodFormError extends ZodError {
     this.name = 'ZodFormError'
   }
 }
+
+export class ServerError extends Error {
+  constructor(message: string, options?: ErrorOptions) {
+    super(message, options)
+    this.name = 'ServerError'
+  }
+}

--- a/src/server/actions/auth/setSignInPassword.ts
+++ b/src/server/actions/auth/setSignInPassword.ts
@@ -7,7 +7,9 @@ import {db} from '../../db'
 import {users} from '../../db/schema/user'
 import {requireServerSession} from '../../utils/auth'
 
-export const setSignInPassword = async (password: string) => {
+import {serializeServerErrors} from '@/lib/utils/common/error'
+
+const setSignInPasswordAction = async (password: string) => {
   const session = await requireServerSession()
 
   const id = session.user.id
@@ -19,3 +21,5 @@ export const setSignInPassword = async (password: string) => {
     .where(eq(users.id, id))
     .returning()
 }
+
+export const setSignInPassword = serializeServerErrors(setSignInPasswordAction)

--- a/src/server/actions/contest/deleteContest.ts
+++ b/src/server/actions/contest/deleteContest.ts
@@ -4,13 +4,17 @@ import {eq} from 'drizzle-orm'
 
 import {db, schema} from '@/server/db'
 import {requireEditableContest} from '@/server/utils/validations/contest'
+import {serializeServerErrors} from '@/lib/utils/common/error'
 
 export type DeleteContestResponse = Awaited<ReturnType<typeof deleteContest>>
 
-export const deleteContest = async (contestId: string) => {
+const deleteContestAction = async (contestId: string) => {
   await requireEditableContest(contestId)
+
   return db
     .delete(schema.contests)
     .where(eq(schema.contests.id, contestId))
     .returning()
 }
+
+export const deleteContest = serializeServerErrors(deleteContestAction)

--- a/src/server/actions/finding/addFindingAttachment.ts
+++ b/src/server/actions/finding/addFindingAttachment.ts
@@ -5,36 +5,35 @@ import {z} from 'zod'
 import {db, schema} from '@/server/db'
 import {insertFindingAttachmentSchema} from '@/server/db/schema/findingAttachment'
 import {requireServerSession} from '@/server/utils/auth'
-import {getApiZodError} from '@/lib/utils/common/error'
+import {serializeServerErrors} from '@/lib/utils/common/error'
+import {ServerError} from '@/lib/types/error'
 
 export type AddFindingAttachmentRequest = z.infer<
   typeof insertFindingAttachmentSchema
 >
 
-export const addFindingAttachment = async (
+const addFindingAttachmentAction = async (
   request: AddFindingAttachmentRequest,
 ) => {
   const session = await requireServerSession()
 
-  const result = insertFindingAttachmentSchema.safeParse(request)
-
-  if (!result.success) {
-    return getApiZodError(result.error)
-  }
-
-  const {findingId} = result.data
+  const attachment = insertFindingAttachmentSchema.parse(request)
 
   const finding = await db.query.findings.findFirst({
-    where: (findings, {eq}) => eq(findings.id, findingId),
+    where: (findings, {eq}) => eq(findings.id, attachment.findingId),
   })
 
   if (!finding) {
-    throw new Error('Finding not found.')
+    throw new ServerError('Finding not found.')
   }
 
   if (finding.authorId === session.user.id) {
-    throw new Error('Only finding author can add attachments.')
+    throw new ServerError('Only finding author can add attachments.')
   }
 
-  return db.insert(schema.findingAttachments).values(result.data).returning()
+  return db.insert(schema.findingAttachments).values(attachment).returning()
 }
+
+export const addFindingAttachment = serializeServerErrors(
+  addFindingAttachmentAction,
+)

--- a/src/server/actions/finding/deleteFinding.ts
+++ b/src/server/actions/finding/deleteFinding.ts
@@ -4,10 +4,11 @@ import {eq} from 'drizzle-orm'
 
 import {db, schema} from '@/server/db'
 import {requireEditableFinding} from '@/server/utils/validations/finding'
+import {serializeServerErrors} from '@/lib/utils/common/error'
 
 export type DeleteFindingResponse = Awaited<ReturnType<typeof deleteFinding>>
 
-export const deleteFinding = async (findingId: string) => {
+const deleteFindingAction = async (findingId: string) => {
   await requireEditableFinding(findingId)
 
   return db
@@ -15,3 +16,5 @@ export const deleteFinding = async (findingId: string) => {
     .where(eq(schema.findings.id, findingId))
     .returning()
 }
+
+export const deleteFinding = serializeServerErrors(deleteFindingAction)

--- a/src/server/actions/finding/editFinding.ts
+++ b/src/server/actions/finding/editFinding.ts
@@ -5,7 +5,7 @@ import {z} from 'zod'
 
 import {db, schema} from '@/server/db'
 import {requireEditableFinding} from '@/server/utils/validations/finding'
-import {getApiZodError} from '@/lib/utils/common/error'
+import {serializeServerErrors} from '@/lib/utils/common/error'
 import {addFindingSchema} from '@/server/utils/validations/schemas'
 
 const editFindingSchema = addFindingSchema
@@ -21,14 +21,8 @@ export type EditFindingRequest = {
 }
 
 // TODO: Edit finding attachments
-export const editFinding = async (request: EditFindingRequest) => {
-  const result = editFindingSchema.safeParse(request.finding)
-
-  if (!result.success) {
-    return getApiZodError(result.error)
-  }
-
-  const updatedFinding = result.data
+const editFindingAction = async (request: EditFindingRequest) => {
+  const updatedFinding = editFindingSchema.parse(request.finding)
 
   await requireEditableFinding(updatedFinding.id)
 
@@ -38,3 +32,5 @@ export const editFinding = async (request: EditFindingRequest) => {
     .where(eq(schema.findings.id, updatedFinding.id))
     .returning()
 }
+
+export const editFinding = serializeServerErrors(editFindingAction)

--- a/src/server/actions/reward/finalizeRewards.ts
+++ b/src/server/actions/reward/finalizeRewards.ts
@@ -2,20 +2,21 @@
 
 import {eq} from 'drizzle-orm'
 
-import {calculateRewards} from './calculateRewards'
+import {calculateRewardsAction} from './calculateRewards'
 
 import {db, schema} from '@/server/db'
 import {ContestStatus} from '@/server/db/models'
 import {requireJudgeAuth} from '@/server/utils/auth'
+import {serializeServerErrors} from '@/lib/utils/common/error'
 
 export type FinalizeRewardsResponse = Awaited<
   ReturnType<typeof finalizeRewards>
 >
 
-export const finalizeRewards = async (contestId: string) => {
+const finalizeRewardsAction = async (contestId: string) => {
   await requireJudgeAuth()
 
-  const {rewards, totalRewards} = await calculateRewards(contestId)
+  const {totalRewards, rewards} = await calculateRewardsAction(contestId)
 
   return db.transaction(async (tx) => {
     await tx
@@ -29,3 +30,5 @@ export const finalizeRewards = async (contestId: string) => {
     return tx.insert(schema.rewards).values(rewards).returning()
   })
 }
+
+export const finalizeRewards = serializeServerErrors(finalizeRewardsAction)

--- a/src/server/actions/reward/getReward.ts
+++ b/src/server/actions/reward/getReward.ts
@@ -2,13 +2,15 @@
 
 import {db} from '../../db'
 
+import {getApiError} from '@/lib/utils/common/error'
+
 export const getReward = async (id: string) => {
   const reward = await db.query.rewards.findFirst({
     where: (reward, {eq}) => eq(reward.id, id),
   })
 
   if (!reward) {
-    throw new Error('Reward not found')
+    return getApiError('Reward not found')
   }
 
   return reward
@@ -31,7 +33,7 @@ export const getRewardPaymentDetails = async (id: string) => {
   })
 
   if (!reward) {
-    throw new Error('Reward not found')
+    return getApiError('Reward not found')
   }
 
   return {

--- a/src/server/actions/reward/storeRewardTxHash.ts
+++ b/src/server/actions/reward/storeRewardTxHash.ts
@@ -7,7 +7,8 @@ import {db} from '../../db'
 import {rewards} from '../../db/schema/reward'
 import {requireJudgeAuth} from '../../utils/auth'
 
-import {getApiZodError} from '@/lib/utils/common/error'
+import {serializeServerErrors} from '@/lib/utils/common/error'
+import {ServerError} from '@/lib/types/error'
 
 const storeRewardTxHashSchema = z.object({
   rewardId: z.string().uuid(),
@@ -16,22 +17,18 @@ const storeRewardTxHashSchema = z.object({
 
 type StoreRewardTxHashRequest = z.infer<typeof storeRewardTxHashSchema>
 
-export const storeRewardTxHash = async (request: StoreRewardTxHashRequest) => {
+export const storeRewardTxHashAction = async (
+  request: StoreRewardTxHashRequest,
+) => {
   await requireJudgeAuth()
-  const result = storeRewardTxHashSchema.safeParse(request)
-
-  if (!result.success) {
-    return getApiZodError(result.error)
-  }
-
-  const {rewardId, txHash} = result.data
+  const {rewardId, txHash} = storeRewardTxHashSchema.parse(request)
 
   const reward = await db.query.rewards.findFirst({
     where: (rewards, {eq}) => eq(rewards.id, rewardId),
   })
 
   if (!reward) {
-    throw new Error('Reward not found.')
+    throw new ServerError('Reward not found.')
   }
 
   return db
@@ -43,3 +40,5 @@ export const storeRewardTxHash = async (request: StoreRewardTxHashRequest) => {
     .where(eq(rewards.id, rewardId))
     .returning()
 }
+
+export const storeRewardTxHash = serializeServerErrors(storeRewardTxHashAction)

--- a/src/server/actions/user/getUser.ts
+++ b/src/server/actions/user/getUser.ts
@@ -3,7 +3,10 @@
 import {db} from '../../db'
 import {requireServerSession} from '../../utils/auth'
 
-export const getUser = async () => {
+import {ServerError} from '@/lib/types/error'
+import {serializeServerErrors} from '@/lib/utils/common/error'
+
+const getUserAction = async () => {
   const session = await requireServerSession()
 
   const user = await db.query.users.findFirst({
@@ -11,8 +14,10 @@ export const getUser = async () => {
   })
 
   if (!user) {
-    throw new Error('User not found')
+    throw new ServerError('User not found')
   }
 
   return user
 }
+
+export const getUser = serializeServerErrors(getUserAction)

--- a/src/server/actions/user/setUserAlias.ts
+++ b/src/server/actions/user/setUserAlias.ts
@@ -6,9 +6,10 @@ import {db} from '../../db'
 import {users} from '../../db/schema/user'
 import {requireServerSession} from '../../utils/auth'
 
-import {getApiFormError} from '@/lib/utils/common/error'
+import {FormError} from '@/lib/types/error'
+import {serializeServerErrors} from '@/lib/utils/common/error'
 
-export const setUserAlias = async (alias: string | null) => {
+const setUserAliasAction = async (alias: string | null) => {
   const session = await requireServerSession()
   const id = session.user.id
 
@@ -20,8 +21,10 @@ export const setUserAlias = async (alias: string | null) => {
   )
 
   if (doesAliasExists) {
-    return getApiFormError('Alias already exists')
+    throw new FormError('Alias already exists')
   }
 
   return db.update(users).set({alias}).where(eq(users.id, id)).returning()
 }
+
+export const setUserAlias = serializeServerErrors(setUserAliasAction)

--- a/src/server/actions/user/setUserAlias.ts
+++ b/src/server/actions/user/setUserAlias.ts
@@ -21,7 +21,7 @@ const setUserAliasAction = async (alias: string | null) => {
   )
 
   if (doesAliasExists) {
-    throw new FormError('Alias already exists')
+    throw new FormError('Alias already exists.')
   }
 
   return db.update(users).set({alias}).where(eq(users.id, id)).returning()

--- a/src/server/utils/auth.ts
+++ b/src/server/utils/auth.ts
@@ -4,6 +4,8 @@ import {Session, getServerSession} from 'next-auth'
 import {authOptions} from '../authOptions'
 import {UserRole} from '../db/models'
 
+import {ServerError} from '@/lib/types/error'
+
 export const getServerAuthSession = () => getServerSession(authOptions)
 
 export const getUserId = async () => {
@@ -15,7 +17,7 @@ export const requireServerSession = async () => {
   const session = await getServerAuthSession()
 
   if (!session) {
-    throw new Error('Not authenticated')
+    throw new ServerError('Not authenticated.')
   }
 
   return session
@@ -35,7 +37,7 @@ export const requireJudgeAuth = async () => {
   const session = await getServerAuthSession()
 
   if (!session || session.user.role !== UserRole.JUDGE) {
-    throw new Error('Not authorized - JUDGE role is required.')
+    throw new ServerError('Not authorized - JUDGE role is required.')
   }
 
   return session

--- a/src/server/utils/validations/contest.ts
+++ b/src/server/utils/validations/contest.ts
@@ -1,5 +1,6 @@
 import {requireServerSession} from '../auth'
 
+import {ServerError} from '@/lib/types/error'
 import {db} from '@/server/db'
 import {ContestStatus} from '@/server/db/models'
 
@@ -17,18 +18,18 @@ export const requireEditableContest = async (contestId: string) => {
   })
 
   if (!contest) {
-    throw new Error('Contest not found.')
+    throw new ServerError('Contest not found.')
   }
 
   if (contest.authorId !== session.user.id) {
-    throw new Error('Only authors or admins can update the contests.')
+    throw new ServerError('Only authors or admins can update the contests.')
   }
 
   if (
     contest.status !== ContestStatus.PENDING &&
     contest.status !== ContestStatus.DRAFT
   ) {
-    throw new Error('Only pending or draft contests can be edited.')
+    throw new ServerError('Only pending or draft contests can be edited.')
   }
 
   return contest

--- a/src/server/utils/validations/finding.ts
+++ b/src/server/utils/validations/finding.ts
@@ -4,6 +4,7 @@ import {requireServerSession} from '../auth'
 
 import {db} from '@/server/db'
 import {FindingStatus} from '@/server/db/models'
+import {ServerError} from '@/lib/types/error'
 
 export const requireEditableFinding = async (findingId: string) => {
   const session = await requireServerSession()
@@ -20,22 +21,22 @@ export const requireEditableFinding = async (findingId: string) => {
   })
 
   if (!finding) {
-    throw new Error('Finding not found.')
+    throw new ServerError('Finding not found.')
   }
 
   if (finding.authorId !== session.user.id) {
-    throw new Error('Only authors can update their findings.')
+    throw new ServerError('Only authors can update their findings.')
   }
 
   if (isPast(finding.contest.endDate)) {
-    throw new Error('Contest has ended.')
+    throw new ServerError('Contest has ended.')
   }
 
   if (
     finding.status !== FindingStatus.DRAFT &&
     finding.status !== FindingStatus.PENDING
   ) {
-    throw new Error(
+    throw new ServerError(
       'Finding cannot be changed after it’s been confirmed or rejected.',
     )
   }


### PR DESCRIPTION
Errors thrown inside server actions have their messages hidden in production. This PR reworks server action errors and adds serialization to those errors, that we want to display to users. 

We could also consider wrapping db inserts/updates in try catch and serialize these errors as well, but for now I leave them as it is.