### PR TITLE
[BUBO-90] My submissions page pagination and sorting

### DIFF
--- a/src/app/(findings)/my-findings/page.tsx
+++ b/src/app/(findings)/my-findings/page.tsx
@@ -6,12 +6,20 @@ import {requirePageSession} from '@/server/utils/auth'
 import {prefetchGetMyFindings} from '@/lib/queries/finding/getMyFinding'
 import {prefetchGetMyFindingsCounts} from '@/lib/queries/finding/getMyFindingsCounts'
 import FindingsDashboardOverview from '@/components/sections/finding/FindingsDashboardOverview'
-import MyFindings from '@/components/sections/finding/MyFindings'
+import MyFindings, {
+  MY_FINDINGS_PAGE_SIZE,
+} from '@/components/sections/finding/MyFindings'
 
 const MySubmissionsPage = async () => {
-  await requirePageSession()
+  const session = await requirePageSession()
 
-  await Promise.all([prefetchGetMyFindingsCounts(), prefetchGetMyFindings({})])
+  await Promise.all([
+    prefetchGetMyFindingsCounts(),
+    prefetchGetMyFindings(session.user.id, {
+      pageParams: {limit: MY_FINDINGS_PAGE_SIZE, offset: 0},
+      sort: undefined,
+    }),
+  ])
 
   return (
     <main className="mt-12 flex flex-grow flex-col">

--- a/src/app/(findings)/my-findings/rewards/page.tsx
+++ b/src/app/(findings)/my-findings/rewards/page.tsx
@@ -7,22 +7,18 @@ import Separator from '@/components/ui/Separator'
 import MyFindingsRewardsTable, {
   MY_FINDINGS_REWARDS_PAGE_SIZE,
 } from '@/components/sections/finding/rewards/MyFindingsRewardsTable'
-import {
-  prefetchGetMyFindingsRewards,
-  prefetchGetMyFindingsRewardsCount,
-} from '@/lib/queries/reward/getMyFindingsRewards'
+import {prefetchGetMyFindingsRewards} from '@/lib/queries/reward/getMyFindingsRewards'
 
 const myFindingsRewardsPage = async () => {
   const {user} = await requirePageSession()
 
-  await Promise.all([
-    prefetchGetMyFindingsRewards(user.id, {
+  await prefetchGetMyFindingsRewards(user.id, {
+    pageParams: {
       limit: MY_FINDINGS_REWARDS_PAGE_SIZE,
       offset: 0,
-      sort: undefined,
-    }),
-    prefetchGetMyFindingsRewardsCount(user.id),
-  ])
+    },
+    sort: undefined,
+  })
 
   return (
     <main className="mt-12 flex flex-grow flex-col">

--- a/src/app/(general)/contests/[id]/page.tsx
+++ b/src/app/(general)/contests/[id]/page.tsx
@@ -12,8 +12,10 @@ const ContestDetailPage = async ({params}: {params: {id: string}}) => {
     prefetchGetContest(params.id),
     prefetchGetContestLeaderboard({
       contestId: params.id,
-      offset: 0,
-      limit: CONTEST_LEADERBOARD_PAGE_SIZE,
+      pageParams: {
+        offset: 0,
+        limit: CONTEST_LEADERBOARD_PAGE_SIZE,
+      },
     }),
   ])
 

--- a/src/app/(general)/contests/[id]/page.tsx
+++ b/src/app/(general)/contests/[id]/page.tsx
@@ -4,10 +4,7 @@ import backgroundImage from '@public/images/background-graphic.png'
 import {prefetchGetContest} from '@/lib/queries/contest/getContest'
 import HydrationBoundary from '@/components/helpers/HydrationBoundary'
 import ContestDetails from '@/components/sections/contest/ContestDetails/ContestDetails'
-import {
-  prefetchGetContestLeaderboard,
-  prefetchGetContestLeaderboardCount,
-} from '@/lib/queries/contest/getContestLeaderboard'
+import {prefetchGetContestLeaderboard} from '@/lib/queries/contest/getContestLeaderboard'
 import {CONTEST_LEADERBOARD_PAGE_SIZE} from '@/components/sections/contest/ContestDetails/ContestLeaderboard'
 
 const ContestDetailPage = async ({params}: {params: {id: string}}) => {
@@ -18,7 +15,6 @@ const ContestDetailPage = async ({params}: {params: {id: string}}) => {
       offset: 0,
       limit: CONTEST_LEADERBOARD_PAGE_SIZE,
     }),
-    prefetchGetContestLeaderboardCount(params.id),
   ])
 
   return (

--- a/src/app/(projects)/my-projects/[contestId]/page.tsx
+++ b/src/app/(projects)/my-projects/[contestId]/page.tsx
@@ -18,8 +18,10 @@ const MyProjectDetailPage = async ({params}: {params: {contestId: string}}) => {
     prefetchGetContest(params.contestId),
     prefetchGetDeduplicatedFindings({
       contestId: params.contestId,
-      limit: MY_PROJECT_VULNERABILITIES_PAGE_SIZE,
-      offset: 0,
+      pageParams: {
+        limit: MY_PROJECT_VULNERABILITIES_PAGE_SIZE,
+        offset: 0,
+      },
       sort: undefined,
     }),
     prefetchGetDeduplicatedFindingsCount(params.contestId),

--- a/src/components/sections/contest/ContestDetails/ContestLeaderboard.tsx
+++ b/src/components/sections/contest/ContestDetails/ContestLeaderboard.tsx
@@ -24,10 +24,7 @@ export const CONTEST_LEADERBOARD_PAGE_SIZE = 7
 
 const ContestLeaderboard = ({contestId}: ContestLeaderboardProps) => {
   const [page] = useSearchParamsNumericState('page', 1)
-  const {
-    data: {data: leaderboard, isLoading},
-    pageParams: {totalCount},
-  } = useGetContestLeaderboard({
+  const {data: leaderboard, isLoading} = useGetContestLeaderboard({
     contestId: contestId,
     pageParams: {
       limit: CONTEST_LEADERBOARD_PAGE_SIZE,
@@ -47,7 +44,7 @@ const ContestLeaderboard = ({contestId}: ContestLeaderboardProps) => {
     )
   }
 
-  if (!leaderboard) {
+  if (!leaderboard?.data) {
     return notFound()
   }
 
@@ -69,7 +66,7 @@ const ContestLeaderboard = ({contestId}: ContestLeaderboardProps) => {
           </TableRow>
         </TableHeader>
         <TableBody className="[&_tr]:border-b-0">
-          {leaderboard.map((leaderboard, idx) => (
+          {leaderboard.data.map((leaderboard, idx) => (
             <TableRow key={leaderboard.userId} className="bg-grey-90">
               <TableCell className="text-titleS">
                 {idx + 1}. {leaderboard.alias ?? leaderboard.userId}
@@ -100,11 +97,11 @@ const ContestLeaderboard = ({contestId}: ContestLeaderboardProps) => {
         </TableBody>
       </Table>
 
-      {!!totalCount && (
+      {!!leaderboard.pageParams.totalCount && (
         <TablePagination
           className="mt-12"
           pageSize={CONTEST_LEADERBOARD_PAGE_SIZE}
-          totalCount={totalCount}
+          totalCount={leaderboard.pageParams.totalCount}
         />
       )}
     </>

--- a/src/components/sections/contest/ContestDetails/ContestLeaderboard.tsx
+++ b/src/components/sections/contest/ContestDetails/ContestLeaderboard.tsx
@@ -11,10 +11,7 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/Table'
-import {
-  useGetContestLeaderboard,
-  useGetContestLeaderboardCount,
-} from '@/lib/queries/contest/getContestLeaderboard'
+import {useGetContestLeaderboard} from '@/lib/queries/contest/getContestLeaderboard'
 import {formatAda} from '@/lib/utils/common/format'
 import {useSearchParamsNumericState} from '@/lib/hooks/useSearchParamsState'
 import TablePagination from '@/components/ui/TablePagination'
@@ -27,11 +24,15 @@ export const CONTEST_LEADERBOARD_PAGE_SIZE = 7
 
 const ContestLeaderboard = ({contestId}: ContestLeaderboardProps) => {
   const [page] = useSearchParamsNumericState('page', 1)
-  const {data: totalSize} = useGetContestLeaderboardCount(contestId)
-  const {data: leaderboard, isLoading} = useGetContestLeaderboard({
+  const {
+    data: {data: leaderboard, isLoading},
+    pageParams: {totalCount},
+  } = useGetContestLeaderboard({
     contestId: contestId,
-    limit: CONTEST_LEADERBOARD_PAGE_SIZE,
-    offset: (page - 1) * CONTEST_LEADERBOARD_PAGE_SIZE,
+    pageParams: {
+      limit: CONTEST_LEADERBOARD_PAGE_SIZE,
+      offset: (page - 1) * CONTEST_LEADERBOARD_PAGE_SIZE,
+    },
   })
 
   if (isLoading) {
@@ -99,11 +100,11 @@ const ContestLeaderboard = ({contestId}: ContestLeaderboardProps) => {
         </TableBody>
       </Table>
 
-      {!!totalSize?.count && (
+      {!!totalCount && (
         <TablePagination
           className="mt-12"
           pageSize={CONTEST_LEADERBOARD_PAGE_SIZE}
-          totalCount={totalSize.count}
+          totalCount={totalCount}
         />
       )}
     </>

--- a/src/components/sections/finding/MyFindings.tsx
+++ b/src/components/sections/finding/MyFindings.tsx
@@ -33,10 +33,7 @@ const MyFindings = () => {
   const [sortParams, {getSortParamsUpdaters: updateSortSearchParams}] =
     useSortingSearchParams(MyFindingsSorting)
 
-  const {
-    data: {data: findings, isLoading},
-    pageParams: {totalCount},
-  } = useGetMyFindings({
+  const {data: findings, isLoading} = useGetMyFindings({
     type: findingType,
     pageParams: {
       limit: MY_FINDINGS_PAGE_SIZE,
@@ -47,7 +44,7 @@ const MyFindings = () => {
 
   const liveFindings = useMemo(
     () =>
-      findings?.filter(
+      findings?.data.filter(
         (finding) =>
           DateTime.fromJSDate(finding.contest.startDate) < DateTime.now() &&
           DateTime.fromJSDate(finding.contest.endDate) > DateTime.now(),
@@ -57,7 +54,7 @@ const MyFindings = () => {
 
   const pastFindings = useMemo(
     () =>
-      findings?.filter(
+      findings?.data.filter(
         (finding) =>
           DateTime.fromJSDate(finding.contest.endDate) < DateTime.now(),
       ),
@@ -73,6 +70,18 @@ const MyFindings = () => {
     }
   }, [findingType, liveFindings, pastFindings])
 
+  const pastCount = findings?.pageParams.pastCount
+  const liveCount = findings?.pageParams.liveCount
+
+  const currentCount = useMemo(() => {
+    switch (findingType) {
+      case FindingOccurence.PRESENT:
+        return liveCount
+      case FindingOccurence.PAST:
+        return pastCount
+    }
+  }, [findingType, liveCount, pastCount])
+
   return (
     <div className="flex flex-grow flex-col">
       <Tabs
@@ -83,11 +92,11 @@ const MyFindings = () => {
           <TabsTrigger
             value={
               FindingOccurence.PRESENT
-            }>{`Live${formatTabCount(liveFindings?.length)}`}</TabsTrigger>
+            }>{`Live${liveCount ? formatTabCount(liveCount) : ''}`}</TabsTrigger>
           <TabsTrigger
             value={
               FindingOccurence.PAST
-            }>{`Past${formatTabCount(pastFindings?.length)}`}</TabsTrigger>
+            }>{`Past${pastCount ? formatTabCount(pastCount) : ''}`}</TabsTrigger>
         </TabsList>
         <Separator />
         <div className="flex flex-grow flex-col bg-black px-24 pb-24 pt-12">
@@ -101,11 +110,11 @@ const MyFindings = () => {
                 updatePageSearchParams={updatePageSearchParams}
                 updateSortSearchParams={updateSortSearchParams}
               />
-              {!!totalCount && (
+              {!!currentCount && (
                 <TablePagination
                   className="mt-12"
                   pageSize={MY_FINDINGS_PAGE_SIZE}
-                  totalCount={totalCount}
+                  totalCount={currentCount}
                 />
               )}
             </>

--- a/src/components/sections/finding/MyFindingsTable.tsx
+++ b/src/components/sections/finding/MyFindingsTable.tsx
@@ -6,19 +6,30 @@ import MyFindingsTableRow from './MyFindingsTableRow'
 import {Button} from '@/components/ui/Button'
 import {PATHS} from '@/lib/utils/common/paths'
 import {MyFinding} from '@/server/actions/finding/getMyFinding'
+import {Table, TableBody, TableHeader, TableRow} from '@/components/ui/Table'
+import TableHeadWithSort from '@/components/ui/TableHeadWithSort'
+import {SortParams} from '@/lib/utils/common/sorting'
+import {MyFindingsSorting} from '@/lib/types/enums'
 import {
-  Table,
-  TableBody,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from '@/components/ui/Table'
+  SearchParamsUpdater,
+  SearchParamsUpdaterFactory,
+} from '@/lib/hooks/useSearchParamsState'
 
 type MyFindingsTableProps = {
   findings: MyFinding[] | undefined
+  sortParams: SortParams<MyFindingsSorting> | undefined
+  updateSortSearchParams: (
+    params: SortParams<MyFindingsSorting>,
+  ) => SearchParamsUpdater[]
+  updatePageSearchParams: SearchParamsUpdaterFactory<number>
 }
 
-const MyFindingsTable = ({findings}: MyFindingsTableProps) => {
+const MyFindingsTable = ({
+  findings,
+  sortParams,
+  updateSortSearchParams,
+  updatePageSearchParams,
+}: MyFindingsTableProps) => {
   if (!findings?.length) {
     return (
       <div className="flex h-[450px] flex-col items-center justify-center">
@@ -37,14 +48,48 @@ const MyFindingsTable = ({findings}: MyFindingsTableProps) => {
     <Table className="border-separate border-spacing-y-6">
       <TableHeader className="[&_tr]:border-b-0">
         <TableRow>
-          <TableHead className="text-bodyM text-grey-40">Project</TableHead>
-          <TableHead className="text-bodyM text-grey-40">Finding</TableHead>
-          <TableHead className="text-bodyM text-grey-40">Submitted</TableHead>
-          <TableHead className="text-bodyM text-grey-40">Severity</TableHead>
-          <TableHead className="text-bodyM text-grey-40">
-            Project state
-          </TableHead>
-          <TableHead className="text-bodyM text-grey-40">Status</TableHead>
+          <TableHeadWithSort
+            title="Project"
+            sortParams={sortParams}
+            updateSortSearchParams={updateSortSearchParams}
+            sortField={MyFindingsSorting.PROJECT}
+            searchParamsUpdaters={[updatePageSearchParams(1)]}
+          />
+          <TableHeadWithSort
+            title="Finding"
+            sortParams={sortParams}
+            updateSortSearchParams={updateSortSearchParams}
+            sortField={MyFindingsSorting.FINDING}
+            searchParamsUpdaters={[updatePageSearchParams(1)]}
+          />
+          <TableHeadWithSort
+            title="Submitted"
+            sortParams={sortParams}
+            updateSortSearchParams={updateSortSearchParams}
+            sortField={MyFindingsSorting.SUBMITTED}
+            searchParamsUpdaters={[updatePageSearchParams(1)]}
+          />
+          <TableHeadWithSort
+            title="Severity"
+            sortParams={sortParams}
+            updateSortSearchParams={updateSortSearchParams}
+            sortField={MyFindingsSorting.SEVERITY}
+            searchParamsUpdaters={[updatePageSearchParams(1)]}
+          />
+          <TableHeadWithSort
+            title="Project state"
+            sortParams={sortParams}
+            updateSortSearchParams={updateSortSearchParams}
+            sortField={MyFindingsSorting.PROJECT_STATE}
+            searchParamsUpdaters={[updatePageSearchParams(1)]}
+          />
+          <TableHeadWithSort
+            title="Status"
+            sortParams={sortParams}
+            updateSortSearchParams={updateSortSearchParams}
+            sortField={MyFindingsSorting.STATUS}
+            searchParamsUpdaters={[updatePageSearchParams(1)]}
+          />
         </TableRow>
       </TableHeader>
       <TableBody className="[&_tr]:border-b-0">

--- a/src/components/sections/finding/rewards/MyFindingsRewardsTable.tsx
+++ b/src/components/sections/finding/rewards/MyFindingsRewardsTable.tsx
@@ -15,10 +15,7 @@ import {
   TableRow,
 } from '@/components/ui/Table'
 import {PATHS} from '@/lib/utils/common/paths'
-import {
-  useGetMyFindingsRewards,
-  useGetMyFindingsRewardsCount,
-} from '@/lib/queries/reward/getMyFindingsRewards'
+import {useGetMyFindingsRewards} from '@/lib/queries/reward/getMyFindingsRewards'
 import TablePagination from '@/components/ui/TablePagination'
 import {useSearchParamsNumericState} from '@/lib/hooks/useSearchParamsState'
 import {useSortingSearchParams} from '@/lib/hooks/useSortingSearchParams'
@@ -33,10 +30,14 @@ const MyFindingsRewardsTable = () => {
   const [sortParams, {getSortParamsUpdaters: updateSortSearchParams}] =
     useSortingSearchParams(MyFindingsRewardsSorting)
 
-  const {data: totalSize} = useGetMyFindingsRewardsCount()
-  const {data, isLoading} = useGetMyFindingsRewards({
-    limit: MY_FINDINGS_REWARDS_PAGE_SIZE,
-    offset: (page - 1) * MY_FINDINGS_REWARDS_PAGE_SIZE,
+  const {
+    data: {data, isLoading},
+    pageParams: {totalCount},
+  } = useGetMyFindingsRewards({
+    pageParams: {
+      limit: MY_FINDINGS_REWARDS_PAGE_SIZE,
+      offset: (page - 1) * MY_FINDINGS_REWARDS_PAGE_SIZE,
+    },
     sort: sortParams,
   })
 
@@ -123,11 +124,11 @@ const MyFindingsRewardsTable = () => {
         </TableBody>
       </Table>
 
-      {!!totalSize?.count && (
+      {!!totalCount && (
         <TablePagination
           className="mt-12"
           pageSize={MY_FINDINGS_REWARDS_PAGE_SIZE}
-          totalCount={totalSize.count}
+          totalCount={totalCount}
         />
       )}
     </>

--- a/src/components/sections/finding/rewards/MyFindingsRewardsTable.tsx
+++ b/src/components/sections/finding/rewards/MyFindingsRewardsTable.tsx
@@ -30,10 +30,7 @@ const MyFindingsRewardsTable = () => {
   const [sortParams, {getSortParamsUpdaters: updateSortSearchParams}] =
     useSortingSearchParams(MyFindingsRewardsSorting)
 
-  const {
-    data: {data, isLoading},
-    pageParams: {totalCount},
-  } = useGetMyFindingsRewards({
+  const {data, isLoading} = useGetMyFindingsRewards({
     pageParams: {
       limit: MY_FINDINGS_REWARDS_PAGE_SIZE,
       offset: (page - 1) * MY_FINDINGS_REWARDS_PAGE_SIZE,
@@ -53,7 +50,7 @@ const MyFindingsRewardsTable = () => {
     )
   }
 
-  if (!data?.length) {
+  if (!data?.data.length) {
     return (
       <div className="flex h-[450px] flex-col items-center justify-center">
         <p className="mb-12 text-titleL uppercase">There is nothing yet...</p>
@@ -118,17 +115,17 @@ const MyFindingsRewardsTable = () => {
           </TableRow>
         </TableHeader>
         <TableBody className="[&_tr]:border-b-0">
-          {data.map((data) => (
+          {data.data.map((data) => (
             <MyFindingsRewardsTableRow key={data.reward.id} data={data} />
           ))}
         </TableBody>
       </Table>
 
-      {!!totalCount && (
+      {!!data.pageParams.totalCount && (
         <TablePagination
           className="mt-12"
           pageSize={MY_FINDINGS_REWARDS_PAGE_SIZE}
-          totalCount={totalCount}
+          totalCount={data.pageParams.totalCount}
         />
       )}
     </>

--- a/src/components/sections/projects/MyProjectVulnerabilitiesList.tsx
+++ b/src/components/sections/projects/MyProjectVulnerabilitiesList.tsx
@@ -43,8 +43,10 @@ const MyProjectVulnerabilitiesList = ({
     useGetDeduplicatedFindingsCount(contestId)
   const {data, isLoading} = useGetDeduplicatedFindings({
     contestId,
-    limit: MY_PROJECT_VULNERABILITIES_PAGE_SIZE,
-    offset: (page - 1) * MY_PROJECT_VULNERABILITIES_PAGE_SIZE,
+    pageParams: {
+      limit: MY_PROJECT_VULNERABILITIES_PAGE_SIZE,
+      offset: (page - 1) * MY_PROJECT_VULNERABILITIES_PAGE_SIZE,
+    },
     sort: sortParams,
   })
 

--- a/src/lib/queries/contest/getContestLeaderboard.ts
+++ b/src/lib/queries/contest/getContestLeaderboard.ts
@@ -8,9 +8,7 @@ import {
   ContestLeaderboard,
   GetContestLeaderboardParams,
   getContestLeaderboard,
-  getContestLeaderboardCount,
 } from '@/server/actions/contest/getContestLeaderboard'
-import {PaginatedResponse} from '@/lib/utils/common/pagination'
 
 const getContestLeaderboardQueryOptions = (
   params: GetContestLeaderboardParams,
@@ -29,37 +27,10 @@ export const prefetchGetContestLeaderboard = async (
   params: GetContestLeaderboardParams,
 ) => {
   const queryClient = getServerQueryClient()
-  await Promise.all([
-    queryClient.prefetchQuery(getContestLeaderboardQueryOptions(params)),
-    queryClient.prefetchQuery(
-      getContestLeaderboardCountQueryOptions(params.contestId),
-    ),
-  ])
+  await queryClient.prefetchQuery(getContestLeaderboardQueryOptions(params))
 }
-
-const getContestLeaderboardCountQueryOptions = (
-  contestId: string | undefined,
-) => ({
-  queryKey: queryKeys.contests.leaderboardCount(contestId).queryKey,
-  queryFn: withApiErrorHandler(() => {
-    if (!contestId) {
-      throw new Error('Contest ID is required.')
-    }
-
-    return getContestLeaderboardCount(contestId)
-  }),
-})
 
 export const useGetContestLeaderboard = (
   params: GetContestLeaderboardParams,
   options?: Partial<UseQueryOptions<ContestLeaderboard>>,
-): PaginatedResponse<ContestLeaderboard> => {
-  const {data: countData} = useQuery(
-    getContestLeaderboardCountQueryOptions(params.contestId),
-  )
-
-  return {
-    data: useQuery({...getContestLeaderboardQueryOptions(params), ...options}),
-    pageParams: {totalCount: countData?.count},
-  }
-}
+) => useQuery({...getContestLeaderboardQueryOptions(params), ...options})

--- a/src/lib/queries/finding/getMyFinding.ts
+++ b/src/lib/queries/finding/getMyFinding.ts
@@ -7,9 +7,14 @@ import {withApiErrorHandler} from '@/lib/utils/common/error'
 import {
   GetMyFindingParams,
   GetMyFindingsParams,
+  MyFinding,
   getMyFinding,
   getMyFindings,
+  getMyFindingsCount,
 } from '@/server/actions/finding/getMyFinding'
+import {FindingOccurence} from '@/server/db/models'
+import {useUserId} from '@/lib/hooks/useUserId'
+import {PaginatedResponse} from '@/lib/utils/common/pagination'
 
 const getGetMyFindingQueryOptions = (params: GetMyFindingParams) => ({
   queryKey: queryKeys.findings.mineOne(params).queryKey,
@@ -24,15 +29,50 @@ export const prefetchGetMyFinding = async (params: GetMyFindingParams) => {
   await queryClient.prefetchQuery(getGetMyFindingQueryOptions(params))
 }
 
-const getGetMyFindingsQueryOptions = (params: GetMyFindingsParams) => ({
-  queryKey: queryKeys.findings.mine(params).queryKey,
+const getGetMyFindingsQueryOptions = (
+  userId: string | undefined,
+  params: GetMyFindingsParams,
+) => ({
+  queryKey: queryKeys.findings.mine(userId, params).queryKey,
   queryFn: withApiErrorHandler(() => getMyFindings(params)),
 })
 
-export const useGetMyFindings = (params: GetMyFindingsParams) =>
-  useQuery(getGetMyFindingsQueryOptions(params))
+const getGetMyFindingsCountQueryOptions = (
+  userId?: string,
+  type?: FindingOccurence,
+) => ({
+  queryKey: queryKeys.findings.mineTotalSize(userId, type).queryKey,
+  queryFn: withApiErrorHandler(() => getMyFindingsCount(type)),
+})
 
-export const prefetchGetMyFindings = async (params: GetMyFindingsParams) => {
+export const useGetMyFindings = (
+  params: GetMyFindingsParams,
+): PaginatedResponse<MyFinding[]> => {
+  const userId = useUserId()
+
+  const {data: countData} = useQuery({
+    ...getGetMyFindingsCountQueryOptions(userId, params.type),
+    enabled: !!userId,
+  })
+
+  return {
+    data: useQuery({
+      ...getGetMyFindingsQueryOptions(userId, params),
+      enabled: !!userId,
+    }),
+    pageParams: {totalCount: countData?.count},
+  }
+}
+
+export const prefetchGetMyFindings = async (
+  userId: string,
+  params: GetMyFindingsParams,
+) => {
   const queryClient = getServerQueryClient()
-  await queryClient.prefetchQuery(getGetMyFindingsQueryOptions(params))
+  await Promise.all([
+    queryClient.prefetchQuery(getGetMyFindingsQueryOptions(userId, params)),
+    queryClient.prefetchQuery(
+      getGetMyFindingsCountQueryOptions(userId, params.type),
+    ),
+  ])
 }

--- a/src/lib/queries/keys.ts
+++ b/src/lib/queries/keys.ts
@@ -19,6 +19,7 @@ import {
   GetFindingParams,
   GetFindingsParams,
 } from '@/server/actions/finding/getFinding'
+import {FindingOccurence} from '@/server/db/models'
 
 export const queryKeys = createQueryKeyStore({
   users: {
@@ -43,7 +44,14 @@ export const queryKeys = createQueryKeyStore({
     publicCounts: (params: GetPublicContestCountsParams) => [params],
   },
   findings: {
-    mine: (params: GetMyFindingsParams) => [params],
+    mine: (userId: string | undefined, params: GetMyFindingsParams) => [
+      userId,
+      params,
+    ],
+    mineTotalSize: (userId: string | undefined, type?: FindingOccurence) => [
+      userId,
+      type,
+    ],
     mineOne: (params: GetMyFindingParams) => [params],
     counts: null,
     byDeduplicatedFinding: (params: GetFindingsParams) => [params],

--- a/src/lib/queries/keys.ts
+++ b/src/lib/queries/keys.ts
@@ -19,7 +19,6 @@ import {
   GetFindingParams,
   GetFindingsParams,
 } from '@/server/actions/finding/getFinding'
-import {FindingOccurence} from '@/server/db/models'
 
 export const queryKeys = createQueryKeyStore({
   users: {
@@ -31,13 +30,11 @@ export const queryKeys = createQueryKeyStore({
       userId,
       params,
     ],
-    totalSize: (userId: string | undefined) => [userId],
     calculated: (contestId: string) => [contestId],
   },
   contests: {
     one: (contestId: string | undefined) => [contestId],
     leaderboard: (params: GetContestLeaderboardParams) => [params],
-    leaderboardCount: (contestId: string | undefined) => [contestId],
     mine: (params: GetMyContestsParams) => [params],
     reportCounts: null,
     public: (params: GetPublicContestsParams) => [params],
@@ -47,10 +44,6 @@ export const queryKeys = createQueryKeyStore({
     mine: (userId: string | undefined, params: GetMyFindingsParams) => [
       userId,
       params,
-    ],
-    mineTotalSize: (userId: string | undefined, type?: FindingOccurence) => [
-      userId,
-      type,
     ],
     mineOne: (params: GetMyFindingParams) => [params],
     counts: null,

--- a/src/lib/queries/reward/getMyFindingsRewards.ts
+++ b/src/lib/queries/reward/getMyFindingsRewards.ts
@@ -7,11 +7,8 @@ import {withApiErrorHandler} from '@/lib/utils/common/error'
 import {useUserId} from '@/lib/hooks/useUserId'
 import {
   GetMyFindingsRewardsParams,
-  MyFindingsReward,
   getMyFindingsRewards,
-  getMyFindingsRewardsCount,
 } from '@/server/actions/reward/getMyFindingsRewards'
-import {PaginatedResponse} from '@/lib/utils/common/pagination'
 
 const getMyFindingsRewardsQueryOptions = (
   userId: string | undefined,
@@ -26,28 +23,13 @@ export const prefetchGetMyFindingsRewards = async (
   params: GetMyFindingsRewardsParams,
 ) => {
   const queryClient = getServerQueryClient()
-  await Promise.all([
-    queryClient.prefetchQuery(getMyFindingsRewardsQueryOptions(userId, params)),
-    queryClient.prefetchQuery(getMyFindingsRewardsCountQueryOptions(userId)),
-  ])
+  await queryClient.prefetchQuery(
+    getMyFindingsRewardsQueryOptions(userId, params),
+  )
 }
 
-const getMyFindingsRewardsCountQueryOptions = (userId: string | undefined) => ({
-  queryKey: queryKeys.rewards.totalSize(userId).queryKey,
-  queryFn: withApiErrorHandler(() => getMyFindingsRewardsCount()),
-})
-
-export const useGetMyFindingsRewards = (
-  params: GetMyFindingsRewardsParams,
-): PaginatedResponse<MyFindingsReward[]> => {
+export const useGetMyFindingsRewards = (params: GetMyFindingsRewardsParams) => {
   const userId = useUserId()
 
-  const {data: countData} = useQuery(
-    getMyFindingsRewardsCountQueryOptions(userId),
-  )
-
-  return {
-    data: useQuery(getMyFindingsRewardsQueryOptions(userId, params)),
-    pageParams: {totalCount: countData?.count},
-  }
+  return useQuery(getMyFindingsRewardsQueryOptions(userId, params))
 }

--- a/src/lib/types/enums.ts
+++ b/src/lib/types/enums.ts
@@ -20,6 +20,15 @@ export enum ContestSorting {
   TITLE = 'title',
 }
 
+export enum MyFindingsSorting {
+  PROJECT = 'project',
+  FINDING = 'finding',
+  SUBMITTED = 'submitted',
+  SEVERITY = 'severity',
+  PROJECT_STATE = 'projectState',
+  STATUS = 'status',
+}
+
 export enum MyFindingsRewardsSorting {
   PROJECT = 'project',
   SUBMITTED = 'submitted',

--- a/src/lib/utils/common/pagination.ts
+++ b/src/lib/utils/common/pagination.ts
@@ -1,0 +1,17 @@
+import {UseQueryResult} from '@tanstack/react-query'
+
+export type PaginatedParams<T = undefined, S = undefined> = (T extends undefined
+  ? object
+  : T) & {
+  pageParams: {
+    limit: number
+    offset?: number
+  }
+} & (S extends undefined ? object : {sort: S | undefined})
+
+export type PaginatedResponse<T> = {
+  data: UseQueryResult<T>
+  pageParams: {
+    totalCount: number | undefined
+  }
+}

--- a/src/lib/utils/common/pagination.ts
+++ b/src/lib/utils/common/pagination.ts
@@ -1,5 +1,3 @@
-import {UseQueryResult} from '@tanstack/react-query'
-
 export type PaginatedParams<T = undefined, S = undefined> = (T extends undefined
   ? object
   : T) & {
@@ -8,10 +6,3 @@ export type PaginatedParams<T = undefined, S = undefined> = (T extends undefined
     offset?: number
   }
 } & (S extends undefined ? object : {sort: S | undefined})
-
-export type PaginatedResponse<T> = {
-  data: UseQueryResult<T>
-  pageParams: {
-    totalCount: number | undefined
-  }
-}

--- a/src/lib/utils/common/sorting.ts
+++ b/src/lib/utils/common/sorting.ts
@@ -1,4 +1,4 @@
-import {AnyColumn, SQLWrapper, asc, desc} from 'drizzle-orm'
+import {AnyColumn, SQLWrapper, asc, desc, sql} from 'drizzle-orm'
 
 import {translateEnum} from './enums'
 
@@ -6,10 +6,12 @@ import {contests} from '@/server/db/schema/contest'
 import {
   ContestSorting,
   MyFindingsRewardsSorting,
+  MyFindingsSorting,
   SortDirection,
 } from '@/lib/types/enums'
 import {rewards} from '@/server/db/schema/reward'
 import {findings} from '@/server/db/schema/finding'
+import {ContestStatus, FindingSeverity, FindingStatus} from '@/server/db/models'
 
 export type SortParams<T extends string> = {
   direction: SortDirection
@@ -73,7 +75,48 @@ export const myFindingsRewardsSortFieldMap = {
   [MyFindingsRewardsSorting.PROJECT]: contests.title,
   [MyFindingsRewardsSorting.SUBMITTED]: findings.createdAt,
   [MyFindingsRewardsSorting.REVIEWED]: findings.updatedAt,
-  [MyFindingsRewardsSorting.SEVERITY]: findings.severity,
+  [MyFindingsRewardsSorting.SEVERITY]: sql<number>`
+  CASE ${findings.severity}
+    WHEN ${FindingSeverity.INFO} THEN 1
+    WHEN ${FindingSeverity.LOW} THEN 2
+    WHEN ${FindingSeverity.MEDIUM} THEN 3
+    WHEN ${FindingSeverity.HIGH} THEN 4
+    WHEN ${FindingSeverity.CRITICAL} THEN 5
+    ELSE 6
+  END`,
   [MyFindingsRewardsSorting.REWARD]: rewards.amount,
   [MyFindingsRewardsSorting.STATE]: rewards.transferTxHash,
+}
+
+export const myFindingsSortFieldMap = {
+  [MyFindingsSorting.PROJECT]: contests.title,
+  [MyFindingsSorting.FINDING]: findings.title,
+  [MyFindingsSorting.SUBMITTED]: findings.createdAt,
+  [MyFindingsSorting.SEVERITY]: sql<number>`
+  CASE ${findings.severity}
+    WHEN ${FindingSeverity.INFO} THEN 1
+    WHEN ${FindingSeverity.LOW} THEN 2
+    WHEN ${FindingSeverity.MEDIUM} THEN 3
+    WHEN ${FindingSeverity.HIGH} THEN 4
+    WHEN ${FindingSeverity.CRITICAL} THEN 5
+    ELSE 6
+  END`,
+  [MyFindingsSorting.PROJECT_STATE]: sql<number>`
+  CASE ${contests.status}
+    WHEN ${ContestStatus.REJECTED} THEN 1
+    WHEN ${ContestStatus.DRAFT} THEN 2
+    WHEN ${ContestStatus.PENDING} THEN 3
+    WHEN ${ContestStatus.APPROVED} THEN 4
+    WHEN ${ContestStatus.IN_REVIEW} THEN 5
+    WHEN ${ContestStatus.FINISHED} THEN 6
+    ELSE 7
+  END`,
+  [MyFindingsSorting.STATUS]: sql<number>`
+  CASE ${findings.status}
+    WHEN ${FindingStatus.REJECTED} THEN 1
+    WHEN ${FindingStatus.DRAFT} THEN 2
+    WHEN ${FindingStatus.PENDING} THEN 3
+    WHEN ${FindingStatus.APPROVED} THEN 4
+    ELSE 5
+  END`,
 }

--- a/src/server/__tests__/contest/getContestLeaderboard.test.ts
+++ b/src/server/__tests__/contest/getContestLeaderboard.test.ts
@@ -6,6 +6,7 @@ import {eq} from 'drizzle-orm'
 import {faker} from '@faker-js/faker'
 
 import {trunacateDb} from '../utils/db'
+import {expectAnyString} from '../utils/expect'
 
 import {
   ContestStatus,
@@ -232,49 +233,59 @@ describe('getContestLeaderboard', () => {
 
     await finalizeRewardsAction(contestId)
 
-    const result = await getContestLeaderboard({contestId})
+    const result = await getContestLeaderboard({
+      contestId,
+      pageParams: {limit: 0},
+    })
 
-    expect(result).toEqual([
-      {
-        alias: 'bob',
-        criticalFindings: 1,
-        highFindings: 0,
-        infoFindings: 0,
-        lowFindings: 0,
-        mediumFindings: 0,
-        totalBugs: 1,
-        totalRewards: 834,
-      },
-      {
-        alias: 'alice',
-        criticalFindings: 0,
-        highFindings: 1,
-        infoFindings: 0,
-        lowFindings: 0,
-        mediumFindings: 0,
-        totalBugs: 1,
-        totalRewards: 93,
-      },
-      {
-        alias: 'david',
-        criticalFindings: 0,
-        highFindings: 1,
-        infoFindings: 0,
-        lowFindings: 0,
-        mediumFindings: 0,
-        totalBugs: 1,
-        totalRewards: 72,
-      },
-      {
-        alias: 'charlie',
-        criticalFindings: 0,
-        highFindings: 0,
-        infoFindings: 1,
-        lowFindings: 0,
-        mediumFindings: 0,
-        totalBugs: 1,
-        totalRewards: 0,
-      },
-    ])
+    expect(result).toEqual({
+      data: [
+        {
+          userId: expectAnyString,
+          alias: 'bob',
+          criticalFindings: 1,
+          highFindings: 0,
+          infoFindings: 0,
+          lowFindings: 0,
+          mediumFindings: 0,
+          totalBugs: 1,
+          totalRewards: 834,
+        },
+        {
+          userId: expectAnyString,
+          alias: 'alice',
+          criticalFindings: 0,
+          highFindings: 1,
+          infoFindings: 0,
+          lowFindings: 0,
+          mediumFindings: 0,
+          totalBugs: 1,
+          totalRewards: 93,
+        },
+        {
+          userId: expectAnyString,
+          alias: 'david',
+          criticalFindings: 0,
+          highFindings: 1,
+          infoFindings: 0,
+          lowFindings: 0,
+          mediumFindings: 0,
+          totalBugs: 1,
+          totalRewards: 72,
+        },
+        {
+          userId: expectAnyString,
+          alias: 'charlie',
+          criticalFindings: 0,
+          highFindings: 0,
+          infoFindings: 1,
+          lowFindings: 0,
+          mediumFindings: 0,
+          totalBugs: 1,
+          totalRewards: 0,
+        },
+      ],
+      pageParams: {totalCount: 4},
+    })
   })
 })

--- a/src/server/__tests__/deduplicatedFinding/getDeduplicatedFinding.test.ts
+++ b/src/server/__tests__/deduplicatedFinding/getDeduplicatedFinding.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect, vi, Mock, beforeEach} from 'vitest'
-import {addDays} from 'date-fns'
+import {subDays} from 'date-fns'
 import {getServerSession} from 'next-auth'
 import {v4 as uuidv4} from 'uuid'
 import {faker} from '@faker-js/faker'
@@ -26,10 +26,10 @@ const contestsToInsert: InsertContest = {
   rewardsAmount: '1000',
   customConditions: 'There are four custom conditions.',
   filesInScope: faker.helpers.multiple(() => faker.internet.url()),
-  status: ContestStatus.APPROVED,
+  status: ContestStatus.FINISHED,
   distributedRewardsAmount: '0',
-  startDate: addDays(new Date(), 1),
-  endDate: addDays(new Date(), 2),
+  startDate: subDays(new Date(), 2),
+  endDate: subDays(new Date(), 1),
 }
 
 const deduplicatedFindingsToInsert: InsertDeduplicatedFinding[] = [
@@ -97,8 +97,22 @@ describe('getDeduplicatedFinding', () => {
       throw new Error('Failed to insert deduplicated findings')
     }
 
-    const result = await getDeduplicatedFindingsAction({contestId})
+    const result = await getDeduplicatedFindingsAction({
+      contestId,
+      pageParams: {limit: 10, offset: 0},
+      sort: undefined,
+    })
 
-    expect(result).toEqual(insertedDeduplicatedFindings)
+    const expectedResult = insertedDeduplicatedFindings.map(
+      (deduplicatedFinding) => ({
+        bestFindingId: null,
+        findingsCount: 0,
+        id: deduplicatedFinding.id,
+        severity: deduplicatedFinding.severity,
+        title: deduplicatedFinding.title,
+      }),
+    )
+
+    expect(result).toEqual(expectedResult)
   })
 })

--- a/src/server/__tests__/finding/addFindingAttachment.test.ts
+++ b/src/server/__tests__/finding/addFindingAttachment.test.ts
@@ -111,6 +111,7 @@ describe('addFindingAttachment', () => {
     const request: AddFindingAttachmentRequest = {
       attachmentUrl: 'https://example-file.com/file.txt',
       findingId: insertedFindingId,
+      fileName: 'file.pdf',
     }
 
     const result = await addFindingAttachmentAction(request)
@@ -129,6 +130,7 @@ describe('addFindingAttachment', () => {
       findingId: insertedFindingId,
       id: expectAnyString,
       mimeType: null,
+      fileName: request.fileName,
     }
 
     expect(result).toEqual([expectedFindingAttachment])

--- a/src/server/__tests__/finding/getMyFindings.test.ts
+++ b/src/server/__tests__/finding/getMyFindings.test.ts
@@ -161,6 +161,11 @@ describe('getMyFindings', () => {
 
     const myFindingsRequestPast = await getMyFindingsAction({
       type: FindingOccurence.PAST,
+      pageParams: {
+        limit: 10,
+        offset: 0,
+      },
+      sort: undefined,
     })
 
     const expectedPastFinding: MyFinding = {
@@ -177,10 +182,18 @@ describe('getMyFindings', () => {
       },
     }
 
-    expect(myFindingsRequestPast).toEqual([expectedPastFinding])
+    expect(myFindingsRequestPast).toEqual({
+      data: [expectedPastFinding],
+      pageParams: {liveCount: 1, pastCount: 1},
+    })
 
     const myFindingsRequestPresent = await getMyFindingsAction({
       type: FindingOccurence.PRESENT,
+      pageParams: {
+        limit: 10,
+        offset: 0,
+      },
+      sort: undefined,
     })
 
     const expectedPresentFinding: MyFinding = {
@@ -197,13 +210,21 @@ describe('getMyFindings', () => {
       },
     }
 
-    expect(myFindingsRequestPresent).toEqual([expectedPresentFinding])
+    expect(myFindingsRequestPresent).toEqual({
+      data: [expectedPresentFinding],
+      pageParams: {liveCount: 1, pastCount: 1},
+    })
 
-    const myFindingsRequestAll = await getMyFindingsAction({})
+    const myFindingsRequestAll = await getMyFindingsAction({
+      pageParams: {
+        limit: 10,
+      },
+      sort: undefined,
+    })
 
-    expect(myFindingsRequestAll).toEqual([
-      expectedPastFinding,
-      expectedPresentFinding,
-    ])
+    expect(myFindingsRequestAll).toEqual({
+      data: [expectedPastFinding, expectedPresentFinding],
+      pageParams: {liveCount: 1, pastCount: 1},
+    })
   })
 })

--- a/src/server/__tests__/reward/getMyFindingsRewards.test.ts
+++ b/src/server/__tests__/reward/getMyFindingsRewards.test.ts
@@ -22,10 +22,7 @@ import {InsertFinding} from '@/server/db/schema/finding'
 import {InsertDeduplicatedFinding} from '@/server/db/schema/deduplicatedFinding'
 import {InsertReward} from '@/server/db/schema/reward'
 import {TEST_WALLET_ADDRESS} from '@/server/utils/test'
-import {
-  getMyFindingsRewards,
-  getMyFindingsRewardsCount,
-} from '@/server/actions/reward/getMyFindingsRewards'
+import {getMyFindingsRewards} from '@/server/actions/reward/getMyFindingsRewards'
 
 const contestId = uuidv4()
 const contestAuthorId = uuidv4()
@@ -157,29 +154,33 @@ describe('getMyFindingsRewards', () => {
     await db.insert(schema.rewards).values(rewardToInsert)
 
     const result = await getMyFindingsRewards({
-      limit: 10,
+      pageParams: {
+        limit: 10,
+      },
+      sort: undefined,
     })
 
-    const size = await getMyFindingsRewardsCount()
-
-    expect(result).toEqual([
-      {
-        reward: {
-          id: expectAnyString,
-          amount: rewardToInsert.amount,
-          transferTxHash: rewardToInsert.transferTxHash,
+    expect(result).toEqual({
+      data: [
+        {
+          reward: {
+            id: expectAnyString,
+            amount: rewardToInsert.amount,
+            transferTxHash: rewardToInsert.transferTxHash,
+          },
+          finding: {
+            severity: findingsToInsert[0]?.severity,
+            updatedAt: expectAnyDate,
+            createdAt: expectAnyDate,
+          },
+          contest: {
+            title: contestToInsert.title,
+          },
         },
-        finding: {
-          severity: findingsToInsert[0]?.severity,
-          updatedAt: expectAnyDate,
-          createdAt: expectAnyDate,
-        },
-        contest: {
-          title: contestToInsert.title,
-        },
+      ],
+      pageParams: {
+        totalCount: 1,
       },
-    ])
-
-    expect(size).toEqual({count: 1})
+    })
   })
 })

--- a/src/server/actions/contest/getContestLeaderboard.ts
+++ b/src/server/actions/contest/getContestLeaderboard.ts
@@ -9,12 +9,11 @@ import {findings} from '@/server/db/schema/finding'
 import {rewards} from '@/server/db/schema/reward'
 import {users} from '@/server/db/schema/user'
 import {ContestStatus} from '@/server/db/models'
+import {PaginatedParams} from '@/lib/utils/common/pagination'
 
-export type GetContestLeaderboardParams = {
+export type GetContestLeaderboardParams = PaginatedParams<{
   contestId: string
-  limit: number
-  offset?: number
-}
+}>
 
 export type ContestLeaderboard = Awaited<
   ReturnType<typeof getContestLeaderboardAction>
@@ -22,8 +21,7 @@ export type ContestLeaderboard = Awaited<
 
 const getContestLeaderboardAction = async ({
   contestId,
-  limit,
-  offset = 0,
+  pageParams: {limit, offset = 0},
 }: GetContestLeaderboardParams) => {
   const contest = await db.query.contests.findFirst({
     where: (contests, {eq}) => eq(contests.id, contestId),

--- a/src/server/actions/deduplicatedFinding/getDeduplicatedFinding.ts
+++ b/src/server/actions/deduplicatedFinding/getDeduplicatedFinding.ts
@@ -11,6 +11,7 @@ import {findings} from '@/server/db/schema/finding'
 import {MyProjectVulnerabilitiesSorting, SortDirection} from '@/lib/types/enums'
 import {SortParams, sortByColumn} from '@/lib/utils/common/sorting'
 import {ContestStatus, FindingSeverity} from '@/server/db/models'
+import {PaginatedParams} from '@/lib/utils/common/pagination'
 
 const getDeduplicatedFindingAction = async (deduplicatedFindingId: string) => {
   const session = await requireServerSession()
@@ -52,17 +53,16 @@ export const getDeduplicatedFinding = serializeServerErrors(
   getDeduplicatedFindingAction,
 )
 
-export type GetDeduplicatedFindingsParams = {
-  contestId: string
-  limit: number
-  offset?: number
-  sort?: SortParams<MyProjectVulnerabilitiesSorting>
-}
+export type GetDeduplicatedFindingsParams = PaginatedParams<
+  {
+    contestId: string
+  },
+  SortParams<MyProjectVulnerabilitiesSorting>
+>
 
 export const getDeduplicatedFindingsAction = async ({
   contestId,
-  limit,
-  offset = 0,
+  pageParams: {limit, offset = 0},
   sort = {
     field: MyProjectVulnerabilitiesSorting.SEVERITY,
     direction: SortDirection.DESC,

--- a/src/server/actions/finding/getMyFinding.ts
+++ b/src/server/actions/finding/getMyFinding.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import {gte, lte} from 'drizzle-orm'
+import {and, count, eq, gte, inArray, lte} from 'drizzle-orm'
 
 import {serializeServerErrors} from '@/lib/utils/common/error'
 import {db} from '@/server/db'
@@ -8,6 +8,14 @@ import {FindingOccurence} from '@/server/db/models'
 import {requireServerSession} from '@/server/utils/auth'
 import {contests} from '@/server/db/schema/contest'
 import {ServerError} from '@/lib/types/error'
+import {findings} from '@/server/db/schema/finding'
+import {PaginatedParams} from '@/lib/utils/common/pagination'
+import {
+  SortParams,
+  myFindingsSortFieldMap,
+  sortByColumn,
+} from '@/lib/utils/common/sorting'
+import {MyFindingsSorting, SortDirection} from '@/lib/types/enums'
 
 export type GetMyFindingParams = {
   findingId: string
@@ -56,13 +64,23 @@ const getMyFindingAction = async ({findingId}: GetMyFindingParams) => {
 
 export const getMyFinding = serializeServerErrors(getMyFindingAction)
 
-export type GetMyFindingsParams = {
-  type?: FindingOccurence
-}
+export type GetMyFindingsParams = PaginatedParams<
+  {
+    type?: FindingOccurence
+  },
+  SortParams<MyFindingsSorting>
+>
 
 export type MyFinding = Awaited<ReturnType<typeof getMyFindingsAction>>[number]
 
-export const getMyFindingsAction = async ({type}: GetMyFindingsParams) => {
+export const getMyFindingsAction = async ({
+  type,
+  pageParams: {limit, offset = 0},
+  sort = {
+    direction: SortDirection.DESC,
+    field: MyFindingsSorting.SUBMITTED,
+  },
+}: GetMyFindingsParams) => {
   const session = await requireServerSession()
 
   return db.query.findings.findMany({
@@ -99,7 +117,54 @@ export const getMyFindingsAction = async ({type}: GetMyFindingsParams) => {
         },
       },
     },
+    limit,
+    offset,
+    orderBy: sortByColumn(sort.direction, myFindingsSortFieldMap[sort.field]),
   })
 }
 
 export const getMyFindings = serializeServerErrors(getMyFindingsAction)
+
+const getMyFindingsCountAction = async (type?: FindingOccurence) => {
+  const session = await requireServerSession()
+
+  const myFindingsCount = await db
+    .select({
+      count: count(),
+    })
+    .from(findings)
+    .where(
+      and(
+        eq(findings.authorId, session.user.id),
+        inArray(
+          findings.contestId,
+          db
+            .select({contestId: contests.id})
+            .from(contests)
+            .where(
+              and(
+                type === FindingOccurence.PAST
+                  ? lte(contests.endDate, new Date())
+                  : undefined,
+                type === FindingOccurence.PRESENT
+                  ? and(
+                      lte(contests.startDate, new Date()),
+                      gte(contests.endDate, new Date()),
+                    )
+                  : undefined,
+              ),
+            ),
+        ),
+      ),
+    )
+
+  if (!myFindingsCount[0]) {
+    throw new ServerError('Failed to get my findings total size.')
+  }
+
+  return {count: myFindingsCount[0].count}
+}
+
+export const getMyFindingsCount = serializeServerErrors(
+  getMyFindingsCountAction,
+)

--- a/src/server/actions/finding/getMyFinding.ts
+++ b/src/server/actions/finding/getMyFinding.ts
@@ -90,14 +90,18 @@ export const getMyFindingsAction = async ({
     SELECT ${contests.id}
     FROM ${contests}
     WHERE ${contests.endDate} <= NOW()
-  ))`.as('pastCount')
+  ))`
+      .mapWith(Number)
+      .as('pastCount')
 
   const presentCount =
     sql<number>`COUNT(*) FILTER (WHERE ${findings.contestId} IN (
     SELECT ${contests.id}
     FROM ${contests}
     WHERE ${contests.startDate} <= NOW() AND ${contests.endDate} >= NOW()
-  ))`.as('presentCount')
+  ))`
+      .mapWith(Number)
+      .as('presentCount')
 
   const myFindingsCountQuery = db
     .select({

--- a/src/server/actions/reward/getMyFindingsRewards.ts
+++ b/src/server/actions/reward/getMyFindingsRewards.ts
@@ -15,20 +15,19 @@ import {
 import {MyFindingsRewardsSorting, SortDirection} from '@/lib/types/enums'
 import {findings} from '@/server/db/schema/finding'
 import {contests} from '@/server/db/schema/contest'
+import {PaginatedParams} from '@/lib/utils/common/pagination'
 
 export type MyFindingsReward = Awaited<
   ReturnType<typeof getMyFindingsRewardsAction>
 >[number]
 
-export type GetMyFindingsRewardsParams = {
-  limit: number
-  offset?: number
-  sort?: SortParams<MyFindingsRewardsSorting>
-}
+export type GetMyFindingsRewardsParams = PaginatedParams<
+  undefined,
+  SortParams<MyFindingsRewardsSorting>
+>
 
 const getMyFindingsRewardsAction = async ({
-  limit,
-  offset = 0,
+  pageParams: {limit, offset = 0},
   sort = {
     field: MyFindingsRewardsSorting.SUBMITTED,
     direction: SortDirection.DESC,


### PR DESCRIPTION
[[BUBO-90](https://vacuum.atlassian.net/browse/BUBO-90?atlOrigin=eyJpIjoiZDJjZWI4ZTdlZTk4NDMyZGIwNTVhZjNhMTFkMzc2ZTQiLCJwIjoiaiJ9)] 

- Refactored pagination `useQuery` hooks to integrate with data `useQuery` in a single hook which includes the `totalCount`. Also added new types `PaginatedParams<T, S>` and `PaginatedResponse<T>` which formalizes the structure of pagination and sorting params/response
- Added pagination and sorting to my submissions page

[BUBO-90]: https://vacuum.atlassian.net/browse/BUBO-90?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ